### PR TITLE
Add simple HTTP route to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - REPOSITORY_NAME=./monorepo/antifraud
+    environment:
+      - PORT=8081
+      - SERVICE_NAME=antifraud-svc
     volumes:
         - ./monorepo/antifraud/:/usr/src/app
         - ./go.mod/:/usr/src/app/go.mod
@@ -23,6 +26,9 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - REPOSITORY_NAME=./monorepo/core
+    environment:
+      - PORT=8082
+      - SERVICE_NAME=core-svc        
     volumes:
         - ./monorepo/core/:/usr/src/app
         - ./go.mod/:/usr/src/app/go.mod
@@ -39,6 +45,9 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - REPOSITORY_NAME=./monorepo/customer
+    environment:
+      - PORT=8083
+      - SERVICE_NAME=customer-svc           
     volumes:
         - ./monorepo/customer/:/usr/src/app
         - ./go.mod/:/usr/src/app/go.mod
@@ -55,6 +64,9 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - REPOSITORY_NAME=./monorepo/notification
+    environment:
+      - PORT=8084
+      - SERVICE_NAME=notification-svc          
     volumes:
         - ./monorepo/notification/:/usr/src/app
         - ./go.mod/:/usr/src/app/go.mod
@@ -71,6 +83,9 @@ services:
       dockerfile: Dockerfile.dev
       args:
         - REPOSITORY_NAME=./monorepo/transaction
+    environment:
+      - PORT=8085
+      - SERVICE_NAME=transaction-sv        
     volumes:
         - ./monorepo/transaction/:/usr/src/app
         - ./go.mod/:/usr/src/app/go.mod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         - REPOSITORY_NAME=./monorepo/antifraud
     environment:
-      - PORT=8081
+      - HTTP_SERVER_PORT=8081
       - SERVICE_NAME=antifraud-svc
     volumes:
         - ./monorepo/antifraud/:/usr/src/app
@@ -27,7 +27,7 @@ services:
       args:
         - REPOSITORY_NAME=./monorepo/core
     environment:
-      - PORT=8082
+      - HTTP_SERVER_PORT=8082
       - SERVICE_NAME=core-svc        
     volumes:
         - ./monorepo/core/:/usr/src/app
@@ -46,7 +46,7 @@ services:
       args:
         - REPOSITORY_NAME=./monorepo/customer
     environment:
-      - PORT=8083
+      - HTTP_SERVER_PORT=8083
       - SERVICE_NAME=customer-svc           
     volumes:
         - ./monorepo/customer/:/usr/src/app
@@ -65,7 +65,7 @@ services:
       args:
         - REPOSITORY_NAME=./monorepo/notification
     environment:
-      - PORT=8084
+      - HTTP_SERVER_PORT=8084
       - SERVICE_NAME=notification-svc          
     volumes:
         - ./monorepo/notification/:/usr/src/app
@@ -84,7 +84,7 @@ services:
       args:
         - REPOSITORY_NAME=./monorepo/transaction
     environment:
-      - PORT=8085
+      - HTTP_SERVER_PORT=8085
       - SERVICE_NAME=transaction-sv        
     volumes:
         - ./monorepo/transaction/:/usr/src/app

--- a/monorepo/antifraud/main.go
+++ b/monorepo/antifraud/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "strings"
+)
 
 func main() {
-    fmt.Println("This is the antifraud service")
+    serverPort := os.Getenv("PORT");
+    serviceName := os.Getenv("SERVICE_NAME");
+
+    fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)
+
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("This is the "+ serviceName +" service"));
+    });
+
+    err := http.ListenAndServe(":"+serverPort, nil);
+
+    if err != nil {
+        fmt.Printf("Error starting server: %v\n", err);
+    }
 }

--- a/monorepo/antifraud/main.go
+++ b/monorepo/antifraud/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-    serverPort := os.Getenv("PORT");
+    serverPort := os.Getenv("HTTP_SERVER_PORT");
     serviceName := os.Getenv("SERVICE_NAME");
 
     fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)

--- a/monorepo/core/main.go
+++ b/monorepo/core/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-    serverPort := os.Getenv("PORT");
+    serverPort := os.Getenv("HTTP_SERVER_PORT");
     serviceName := os.Getenv("SERVICE_NAME");
 
     fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)

--- a/monorepo/core/main.go
+++ b/monorepo/core/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "strings"
+)
 
 func main() {
-    fmt.Println("This is the core")
+    serverPort := os.Getenv("PORT");
+    serviceName := os.Getenv("SERVICE_NAME");
+
+    fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)
+
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("This is the "+ serviceName +" service"));
+    });
+
+    err := http.ListenAndServe(":"+serverPort, nil);
+
+    if err != nil {
+        fmt.Printf("Error starting server: %v\n", err);
+    }
 }

--- a/monorepo/customer/main.go
+++ b/monorepo/customer/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-    serverPort := os.Getenv("PORT");
+    serverPort := os.Getenv("HTTP_SERVER_PORT");
     serviceName := os.Getenv("SERVICE_NAME");
 
     fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)

--- a/monorepo/customer/main.go
+++ b/monorepo/customer/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "strings"
+)
 
 func main() {
-    fmt.Println("This is the customer service")
+    serverPort := os.Getenv("PORT");
+    serviceName := os.Getenv("SERVICE_NAME");
+
+    fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)
+
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("This is the "+ serviceName +" service"));
+    });
+
+    err := http.ListenAndServe(":"+serverPort, nil);
+
+    if err != nil {
+        fmt.Printf("Error starting server: %v\n", err);
+    }
 }

--- a/monorepo/notification/main.go
+++ b/monorepo/notification/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "strings"
+)
 
 func main() {
-    fmt.Println("This is the notification service")
+    serverPort := os.Getenv("PORT");
+    serviceName := os.Getenv("SERVICE_NAME");
+
+    fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)
+
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("This is the "+ serviceName +" service"));
+    });
+
+    err := http.ListenAndServe(":"+serverPort, nil);
+
+    if err != nil {
+        fmt.Printf("Error starting server: %v\n", err);
+    }
 }

--- a/monorepo/notification/main.go
+++ b/monorepo/notification/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-    serverPort := os.Getenv("PORT");
+    serverPort := os.Getenv("HTTP_SERVER_PORT");
     serviceName := os.Getenv("SERVICE_NAME");
 
     fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)

--- a/monorepo/transaction/main.go
+++ b/monorepo/transaction/main.go
@@ -1,7 +1,25 @@
 package main
 
-import "fmt"
+import (
+    "fmt"
+    "net/http"
+    "os"
+    "strings"
+)
 
 func main() {
-    fmt.Println("This is the transaction service")
+    serverPort := os.Getenv("PORT");
+    serviceName := os.Getenv("SERVICE_NAME");
+
+    fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)
+
+    http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("This is the "+ serviceName +" service"));
+    });
+
+    err := http.ListenAndServe(":"+serverPort, nil);
+
+    if err != nil {
+        fmt.Printf("Error starting server: %v\n", err);
+    }
 }

--- a/monorepo/transaction/main.go
+++ b/monorepo/transaction/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-    serverPort := os.Getenv("PORT");
+    serverPort := os.Getenv("HTTP_SERVER_PORT");
     serviceName := os.Getenv("SERVICE_NAME");
 
     fmt.Printf("[%s]: is running on port %s\n", strings.ToUpper(serviceName), serverPort)


### PR DESCRIPTION
**O que foi feito ?**

- Implementado uma simples rota http para cada serviço.
- Adicionado variaveis de ambiente no docker-compose


**Obserção:**

Agora é possível executar cada serviço em ambiente localhost usando `http://localhost:[SERVICE PORT]`